### PR TITLE
Encode password in database string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
         image: postgres:latest
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: qyo}Mh{Bn&X[Ppc!dlsrG
           POSTGRES_DB: database
         ports:
           - 5432:5432
@@ -20,10 +20,10 @@ jobs:
       - name: Check with version flag
         uses: ./
         with:
-          database: postgres://postgres:postgres@postgres:5432/database?sslmode=disable
+          database: postgres://postgres:qyo}Mh{Bn&X[Ppc!dlsrG@postgres:5432/database?sslmode=disable
           version: true
       - name: Check basic execution with defaults
         uses: ./
         with:
-          database: postgres://postgres:postgres@postgres:5432/database?sslmode=disable
+          database: postgres://postgres:qyo}Mh{Bn&X[Ppc!dlsrG@postgres:5432/database?sslmode=disable
           verbose: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /app
 
 FROM migrate/migrate
 
+COPY --from=builder ./app ./
+
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.4 as builder
 
 COPY entrypoint.go /entrypoint.go
-COPY go.mod go.sum /
+COPY go.mod /
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app
 
 FROM migrate/migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:1.20.4 as builder
 
 COPY entrypoint.go /entrypoint.go
-RUN go build -o app
+COPY go.mod go.sum /
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app
 
 FROM migrate/migrate
 
-ENTRYPOINT ["./app"]
+ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+FROM golang:1.20.4 as builder
+
+COPY entrypoint.go /entrypoint.go
+RUN go build -o app
+
 FROM migrate/migrate
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["./app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.20.4 as builder
 
+WORKDIR /
 COPY go.mod /
 COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.4 as builder
 
-COPY entrypoint.go /entrypoint.go
 COPY go.mod /
+COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app
 
 FROM migrate/migrate

--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ runs:
   args: 
     - ${{ inputs.path }}
     - ${{ inputs.database }}
-    - ${{ inputs.command }}
     - ${{ inputs.prefetch }}
     - ${{ inputs.lockTimeout }}
     - ${{ inputs.verbose }}
     - ${{ inputs.version }}
+    - ${{ inputs.command }}
 
 branding:
   icon: 'database'

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -31,8 +31,6 @@ func main() {
 		args[4],
 	}
 
-	fmt.Printf("Arguments are: migrate %v", args)
-
 	if len(args[5]) > 0 {
 		arguments = append(arguments, "-verbose")
 	}
@@ -43,7 +41,6 @@ func main() {
 
 	arguments = append(arguments, args[7])
 
-	fmt.Printf("Command is: migrate %v", arguments)
 	cmd := exec.Command("migrate", arguments...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -17,19 +17,19 @@ func main() {
 		fmt.Sprintf("%q", args[1]),
 		"-database",
 		fmt.Sprintf("%q", url.QueryEscape(args[2])),
-		"-prefetch",
-		args[3],
-		"-lock-timeout",
-		args[4],
+		// "-prefetch",
+		// args[3],
+		// "-lock-timeout",
+		// args[4],
 	}
 
-	if len(args[5]) > 0 {
-		arguments = append(arguments, "-verbose")
-	}
+	// if len(args[5]) > 0 {
+	// 	arguments = append(arguments, "-verbose")
+	// }
 
-	if len(args[6]) > 0 {
-		arguments = append(arguments, "-version")
-	}
+	// if len(args[6]) > 0 {
+	// 	arguments = append(arguments, "-version")
+	// }
 
 	arguments = append(arguments, args[7])
 

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 )
@@ -11,7 +12,13 @@ func main() {
 	fmt.Println(len(os.Args), os.Args)
 	args := os.Args
 
-	arguments := []string{args[1], args[2], args[3], args[4]}
+	parsedDatabase, parseErr := url.Parse(args[2])
+	if parseErr != nil {
+		fmt.Println(parseErr)
+	}
+
+	arguments := []string{args[1], parsedDatabase.RequestURI(), args[3], args[4]}
+	fmt.Printf("%v", arguments)
 
 	if len(args[5]) > 0 {
 		arguments = append(arguments, "-verbose")

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -14,9 +14,6 @@ func queryEscape(s string) string {
 	usernamePassword := strings.Split(split[1], "@")
 	password := strings.Split(usernamePassword[0], ":")
 	replaced := strings.Replace(s, password[1], url.QueryEscape(password[1]), 3)
-	fmt.Printf("\n password is %s", password[1])
-	fmt.Printf("\n original string is %s", s)
-	fmt.Printf("\n replaced string is %s", replaced)
 
 	return replaced
 }
@@ -59,5 +56,7 @@ func main() {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitError.ExitCode())
 		}
+	} else {
+		out.String()
 	}
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"os"
@@ -45,18 +44,13 @@ func main() {
 	arguments = append(arguments, args[7])
 
 	fmt.Printf("Command is: migrate %v", arguments)
-	cmd := exec.Command("migrate", arguments...)
-
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
+	out, err := exec.Command("migrate", arguments...).Output()
+	if err != nil {
+		fmt.Println(fmt.Sprint(err))
 		if exitError, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitError.ExitCode())
 		}
 	} else {
-		out.String()
+		fmt.Printf("The date is %s\n", string(out))
 	}
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -13,10 +13,14 @@ func main() {
 	args := os.Args
 
 	arguments := []string{
-		fmt.Sprintf("-path %s", args[1]),
-		fmt.Sprintf("-database %s", url.QueryEscape(args[2])),
-		fmt.Sprintf("-prefetch %s", args[3]),
-		fmt.Sprintf("-lock-timeout %s", args[4]),
+		"-path",
+		args[1],
+		"-database",
+		url.QueryEscape(args[2]),
+		"-prefetch",
+		args[3],
+		"-lock-timeout",
+		args[4],
 	}
 
 	if len(args[5]) > 0 {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -8,32 +8,37 @@ import (
 	"os/exec"
 )
 
+func quote(s string) string {
+	return (&url.URL{Path: s}).RequestURI()
+}
+
 func main() {
-	fmt.Println(len(os.Args), os.Args)
 	args := os.Args
 
 	arguments := []string{
 		"-path",
 		fmt.Sprintf("%q", args[1]),
 		"-database",
-		fmt.Sprintf("%q", url.QueryEscape(args[2])),
-		// "-prefetch",
-		// args[3],
-		// "-lock-timeout",
-		// args[4],
+		fmt.Sprintf("%q", quote(args[2])),
+		"-prefetch",
+		args[3],
+		"-lock-timeout",
+		args[4],
 	}
 
-	// if len(args[5]) > 0 {
-	// 	arguments = append(arguments, "-verbose")
-	// }
+	fmt.Printf("Arguments are: migrate %v", args)
 
-	// if len(args[6]) > 0 {
-	// 	arguments = append(arguments, "-version")
-	// }
+	if len(args[5]) > 0 {
+		arguments = append(arguments, "-verbose")
+	}
+
+	if len(args[6]) > 0 {
+		arguments = append(arguments, "-version")
+	}
 
 	arguments = append(arguments, args[7])
 
-	fmt.Printf("%v", arguments)
+	fmt.Printf("Command is: migrate %v", arguments)
 	cmd := exec.Command("migrate", arguments...)
 
 	var out bytes.Buffer

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -17,7 +17,7 @@ func main() {
 
 	arguments := []string{
 		"-path",
-		fmt.Sprintf("%q", args[1]),
+		args[1],
 		"-database",
 		fmt.Sprintf("%q", quote(args[2])),
 		"-prefetch",

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -13,7 +13,6 @@ func main() {
 	args := os.Args
 
 	arguments := []string{args[1], url.QueryEscape(args[2]), args[3], args[4]}
-	fmt.Printf("%v", arguments)
 
 	if len(args[5]) > 0 {
 		arguments = append(arguments, "-verbose")
@@ -24,15 +23,17 @@ func main() {
 	}
 
 	arguments = append(arguments, args[7])
+	fmt.Printf("%v", arguments)
 	cmd := exec.Command("migrate", arguments...)
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
-		return
+		if exitError, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitError.ExitCode())
+		}
 	}
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -18,7 +18,7 @@ func queryEscape(s string) string {
 	fmt.Printf("\n original string is %s", s)
 	fmt.Printf("\n replaced string is %s", replaced)
 
-	return fmt.Sprintf("\n %s", replaced)
+	return replaced
 }
 
 func main() {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -6,10 +6,15 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 )
 
-func quote(s string) string {
-	return (&url.URL{Path: s}).RequestURI()
+func queryEscape(s string) string {
+	split := strings.Split(s, "://")
+	usernamePassword := strings.Split(split[1], "@")
+	replaced := strings.Replace(s, usernamePassword[0], url.QueryEscape(usernamePassword[0]), 3)
+
+	return fmt.Sprintf("\n %s", replaced)
 }
 
 func main() {
@@ -19,7 +24,7 @@ func main() {
 		"-path",
 		args[1],
 		"-database",
-		quote(args[2]),
+		queryEscape(args[2]),
 		"-prefetch",
 		args[3],
 		"-lock-timeout",

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	fmt.Println(len(os.Args), os.Args)
+	args := os.Args
+
+	arguments := []string{args[1], args[2], args[3], args[4]}
+
+	if len(args[5]) > 0 {
+		arguments = append(arguments, "-verbose")
+	}
+
+	if len(args[6]) > 0 {
+		arguments = append(arguments, "-version")
+	}
+
+	arguments = append(arguments, args[7])
+	cmd := exec.Command("migrate", arguments...)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
+		return
+	}
+}

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -14,13 +14,13 @@ func main() {
 
 	arguments := []string{
 		"-path",
-		fmt.Sprintf("\"%s\"", args[1]),
+		fmt.Sprintf("%q", args[1])),
 		"-database",
-		fmt.Sprintf("\"%s\"", url.QueryEscape(args[2])),
+		fmt.Sprintf("%q",  url.QueryEscape(args[2])),
 		"-prefetch",
-		fmt.Sprintf("\"%s\"", args[3]),
+		args[3],
 		"-lock-timeout",
-		fmt.Sprintf("\"%s\"", args[4]),
+		args[4],
 	}
 
 	if len(args[5]) > 0 {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -13,8 +13,8 @@ func queryEscape(s string) string {
 	split := strings.Split(s, "://")
 	usernamePassword := strings.Split(split[1], "@")
 	password := strings.Split(usernamePassword[0], ":")
-	replaced := strings.Replace(s, password[1], url.QueryEscape(usernamePassword[0]), 3)
-	fmt.Printf("\n password is %s", password)
+	replaced := strings.Replace(s, password[1], url.QueryEscape(password[1]), 3)
+	fmt.Printf("\n password is %s", password[1])
 	fmt.Printf("\n original string is %s", s)
 	fmt.Printf("\n replaced string is %s", replaced)
 

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -14,9 +14,9 @@ func main() {
 
 	arguments := []string{
 		"-path",
-		fmt.Sprintf("%q", args[1])),
+		fmt.Sprintf("%q", args[1]),
 		"-database",
-		fmt.Sprintf("%q",  url.QueryEscape(args[2])),
+		fmt.Sprintf("%q", url.QueryEscape(args[2])),
 		"-prefetch",
 		args[3],
 		"-lock-timeout",

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -12,12 +12,7 @@ func main() {
 	fmt.Println(len(os.Args), os.Args)
 	args := os.Args
 
-	parsedDatabase, parseErr := url.Parse(args[2])
-	if parseErr != nil {
-		fmt.Println(parseErr)
-	}
-
-	arguments := []string{args[1], parsedDatabase.RequestURI(), args[3], args[4]}
+	arguments := []string{args[1], url.QueryEscape(args[2]), args[3], args[4]}
 	fmt.Printf("%v", arguments)
 
 	if len(args[5]) > 0 {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -12,7 +12,12 @@ func main() {
 	fmt.Println(len(os.Args), os.Args)
 	args := os.Args
 
-	arguments := []string{args[1], url.QueryEscape(args[2]), args[3], args[4]}
+	arguments := []string{
+		fmt.Sprintf("-path %s", args[1]),
+		fmt.Sprintf("-database %s", url.QueryEscape(args[2])),
+		fmt.Sprintf("-prefetch %s", args[3]),
+		fmt.Sprintf("-lock-timeout %s", args[4]),
+	}
 
 	if len(args[5]) > 0 {
 		arguments = append(arguments, "-verbose")
@@ -22,8 +27,10 @@ func main() {
 		arguments = append(arguments, "-version")
 	}
 
+	arguments = append(arguments, args[4])
+
 	fmt.Printf("%v", arguments)
-	cmd := exec.Command(fmt.Sprintf("migrate %s", args[7]), arguments...)
+	cmd := exec.Command("migrate", arguments...)
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -12,7 +12,8 @@ import (
 func queryEscape(s string) string {
 	split := strings.Split(s, "://")
 	usernamePassword := strings.Split(split[1], "@")
-	replaced := strings.Replace(s, usernamePassword[0], url.QueryEscape(usernamePassword[0]), 3)
+	password := strings.Split(usernamePassword[0], ":")
+	replaced := strings.Replace(s, password[1], url.QueryEscape(usernamePassword[0]), 3)
 
 	return fmt.Sprintf("\n %s", replaced)
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -14,13 +14,13 @@ func main() {
 
 	arguments := []string{
 		"-path",
-		args[1],
+		fmt.Sprintf("\"%s\"", args[1]),
 		"-database",
-		url.QueryEscape(args[2]),
+		fmt.Sprintf("\"%s\"", url.QueryEscape(args[2])),
 		"-prefetch",
-		args[3],
+		fmt.Sprintf("\"%s\"", args[3]),
 		"-lock-timeout",
-		args[4],
+		fmt.Sprintf("\"%s\"", args[4]),
 	}
 
 	if len(args[5]) > 0 {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -14,6 +14,9 @@ func queryEscape(s string) string {
 	usernamePassword := strings.Split(split[1], "@")
 	password := strings.Split(usernamePassword[0], ":")
 	replaced := strings.Replace(s, password[1], url.QueryEscape(usernamePassword[0]), 3)
+	fmt.Printf("\n password is %s", password)
+	fmt.Printf("\n original string is %s", s)
+	fmt.Printf("\n replaced string is %s", replaced)
 
 	return fmt.Sprintf("\n %s", replaced)
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -22,9 +22,8 @@ func main() {
 		arguments = append(arguments, "-version")
 	}
 
-	arguments = append(arguments, args[7])
 	fmt.Printf("%v", arguments)
-	cmd := exec.Command("migrate", arguments...)
+	cmd := exec.Command(fmt.Sprintf("migrate %s", args[7]), arguments...)
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -44,13 +44,14 @@ func main() {
 	arguments = append(arguments, args[7])
 
 	fmt.Printf("Command is: migrate %v", arguments)
-	out, err := exec.Command("migrate", arguments...).Output()
+	cmd := exec.Command("migrate", arguments...)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(fmt.Sprint(err))
 		if exitError, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitError.ExitCode())
 		}
-	} else {
-		fmt.Printf("The date is %s\n", string(out))
 	}
+
+	fmt.Printf("Result: \n%s\n", string(out))
 }

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -19,7 +19,7 @@ func main() {
 		"-path",
 		args[1],
 		"-database",
-		fmt.Sprintf("%q", quote(args[2])),
+		quote(args[2]),
 		"-prefetch",
 		args[3],
 		"-lock-timeout",

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -27,7 +27,7 @@ func main() {
 		arguments = append(arguments, "-version")
 	}
 
-	arguments = append(arguments, args[4])
+	arguments = append(arguments, args[7])
 
 	fmt.Printf("%v", arguments)
 	cmd := exec.Command("migrate", arguments...)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module migrate-github-action
+
+go 1.20


### PR DESCRIPTION
Password is not being parsed by these rules:

Database connection strings are specified via URLs. The URL format is driver dependent but generally has the form: dbdriver://username:password@host:port/dbname?param1=true&param2=false

Any [reserved URL characters](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters) need to be escaped. Note, the % character also [needs to be escaped](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_the_percent_character)

Explicitly, the following characters need to be escaped: !, #, $, %, &, ', (, ), *, +, ,, /, :, ;, =, ?, @, [, ]

It's easiest to always run the URL parts of your DB connection URL (e.g. username, password, etc) through an URL encoder. See the example Python snippets below: